### PR TITLE
chore: github action 오타 수정

### DIFF
--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -14,4 +14,4 @@ jobs:
         uses: pozil/auto-assign-issue@v2
         with:
           assignees: jong-k
-          numOfAssignees: 1
+          numOfAssignee: 1


### PR DESCRIPTION
PR 자동 어사인 기능은 불필요하여 추가하지 않음(불필요한 대기 발생)